### PR TITLE
Replace post insert event handler type

### DIFF
--- a/src/main/java/io/github/teastman/hibernate/AnnotatedHibernateEventListenerInvoker.java
+++ b/src/main/java/io/github/teastman/hibernate/AnnotatedHibernateEventListenerInvoker.java
@@ -38,7 +38,7 @@ public class AnnotatedHibernateEventListenerInvoker implements
         PreInsertEventListener,
         PreDeleteEventListener,
         PreUpdateEventListener,
-        PostInsertEventListener,
+        PostCommitInsertEventListener,
         PostDeleteEventListener,
         PostUpdateEventListener,
         BeanPostProcessor {
@@ -88,6 +88,10 @@ public class AnnotatedHibernateEventListenerInvoker implements
     @Override
     public void onPostInsert(PostInsertEvent event) {
         onEvent(event, event.getEntity());
+    }
+
+    @Override
+    public void onPostInsertCommitFailed(PostInsertEvent postInsertEvent) {
     }
 
     @Override


### PR DESCRIPTION
Change post insert event handler type to `PostCommitInsertEventListener` due to a [bug](https://hibernate.atlassian.net/browse/HHH-1582) in `PostInsertEventHandler` that causes it to fire before the transaction has been committed. 